### PR TITLE
GraphQL にする

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,68 @@
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
+		"@apollo/client": {
+			"version": "3.3.20",
+			"resolved": "https://registry.npmjs.org/@apollo/client/-/client-3.3.20.tgz",
+			"integrity": "sha512-hS7UmBwJweudw/J3M0RAcusMHNiRuGqkRH6g91PM2ev8cXScIMdXr/++9jo7wD1nAITMCMF4HQQ3LFaw/Or0Bw==",
+			"requires": {
+				"@graphql-typed-document-node/core": "^3.0.0",
+				"@types/zen-observable": "^0.8.0",
+				"@wry/context": "^0.6.0",
+				"@wry/equality": "^0.5.0",
+				"fast-json-stable-stringify": "^2.0.0",
+				"graphql-tag": "^2.12.0",
+				"hoist-non-react-statics": "^3.3.2",
+				"optimism": "^0.16.0",
+				"prop-types": "^15.7.2",
+				"symbol-observable": "^4.0.0",
+				"ts-invariant": "^0.7.0",
+				"tslib": "^1.10.0",
+				"zen-observable": "^0.8.14"
+			},
+			"dependencies": {
+				"@wry/equality": {
+					"version": "0.5.1",
+					"resolved": "https://registry.npmjs.org/@wry/equality/-/equality-0.5.1.tgz",
+					"integrity": "sha512-FZKbdpbcVcbDxQrKcaBClNsQaMg9nof1RKM7mReJe5DKUzM5u8S7T+PqwNqvib5O2j2xxF1R4p5O3+b6baTrbw==",
+					"requires": {
+						"tslib": "^2.1.0"
+					},
+					"dependencies": {
+						"tslib": {
+							"version": "2.3.0",
+							"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+							"integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
+						}
+					}
+				},
+				"symbol-observable": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-4.0.0.tgz",
+					"integrity": "sha512-b19dMThMV4HVFynSAM1++gBHAbk2Tc/osgLIBZMKsyqh34jb2e8Os7T6ZW/Bt3pJFdBTd2JwAnAAEQV7rSNvcQ=="
+				},
+				"ts-invariant": {
+					"version": "0.7.3",
+					"resolved": "https://registry.npmjs.org/ts-invariant/-/ts-invariant-0.7.3.tgz",
+					"integrity": "sha512-UWDDeovyUTIMWj+45g5nhnl+8oo+GhxL5leTaHn5c8FkQWfh8v66gccLd2/YzVmV5hoQUjCEjhrXnQqVDJdvKA==",
+					"requires": {
+						"tslib": "^2.1.0"
+					},
+					"dependencies": {
+						"tslib": {
+							"version": "2.3.0",
+							"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+							"integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
+						}
+					}
+				},
+				"tslib": {
+					"version": "1.14.1",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+					"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+				}
+			}
+		},
 		"@babel/code-frame": {
 			"version": "7.12.11",
 			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.11.tgz",
@@ -121,6 +183,11 @@
 			"resolved": "https://registry.npmjs.org/@fontsource/fira-mono/-/fira-mono-4.3.0.tgz",
 			"integrity": "sha512-EizsZfvV/MLLbOUyonZV6vzispTKOkZrIhWcy3W2Ryn8OLaYw+af34DOfUpIN8U8Q8/wO5lU90iPyXePqmpRdg=="
 		},
+		"@graphql-typed-document-node/core": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/@graphql-typed-document-node/core/-/core-3.1.0.tgz",
+			"integrity": "sha512-wYn6r8zVZyQJ6rQaALBEln5B1pzxb9shV5Ef97kTvn6yVGrqyXVnDqnU24MXnFubR+rZjBY9NWuxX3FB2sTsjg=="
+		},
 		"@lukeed/csprng": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/@lukeed/csprng/-/csprng-1.0.0.tgz",
@@ -234,6 +301,11 @@
 				"@types/node": "*"
 			}
 		},
+		"@types/zen-observable": {
+			"version": "0.8.2",
+			"resolved": "https://registry.npmjs.org/@types/zen-observable/-/zen-observable-0.8.2.tgz",
+			"integrity": "sha512-HrCIVMLjE1MOozVoD86622S7aunluLb2PJdPfb3nYiEtohm8mIB/vyv0Fd37AdeMFrTUQXEunw78YloMA3Qilg=="
+		},
 		"@typescript-eslint/eslint-plugin": {
 			"version": "4.24.0",
 			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.24.0.tgz",
@@ -315,6 +387,22 @@
 			"requires": {
 				"@typescript-eslint/types": "4.24.0",
 				"eslint-visitor-keys": "^2.0.0"
+			}
+		},
+		"@wry/context": {
+			"version": "0.6.0",
+			"resolved": "https://registry.npmjs.org/@wry/context/-/context-0.6.0.tgz",
+			"integrity": "sha512-sAgendOXR8dM7stJw3FusRxFHF/ZinU0lffsA2YTyyIOfic86JX02qlPqPVqJNZJPAxFt+2EE8bvq6ZlS0Kf+Q==",
+			"requires": {
+				"tslib": "^2.1.0"
+			}
+		},
+		"@wry/trie": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/@wry/trie/-/trie-0.3.0.tgz",
+			"integrity": "sha512-Yw1akIogPhAT6XPYsRHlZZIS0tIGmAl9EYXHi2scf7LPKKqdqmow/Hu4kEqP2cJR3EjaU/9L0ZlAjFf3hFxmug==",
+			"requires": {
+				"tslib": "^2.1.0"
 			}
 		},
 		"abbrev": {
@@ -1236,6 +1324,19 @@
 			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
 			"integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ=="
 		},
+		"graphql": {
+			"version": "15.5.0",
+			"resolved": "https://registry.npmjs.org/graphql/-/graphql-15.5.0.tgz",
+			"integrity": "sha512-OmaM7y0kaK31NKG31q4YbD2beNYa6jBBKtMFT6gLYJljHLJr42IqJ8KX08u3Li/0ifzTU5HjmoOOrwa5BRLeDA=="
+		},
+		"graphql-tag": {
+			"version": "2.12.4",
+			"resolved": "https://registry.npmjs.org/graphql-tag/-/graphql-tag-2.12.4.tgz",
+			"integrity": "sha512-VV1U4O+9x99EkNpNmCUV5RZwq6MnK4+pGbRYWG+lA/m3uo7TSqJF81OkcOP148gFP6fzdl7JWYBrwWVTS9jXww==",
+			"requires": {
+				"tslib": "^2.1.0"
+			}
+		},
 		"har-schema": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
@@ -1294,6 +1395,14 @@
 			"version": "10.7.2",
 			"resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.2.tgz",
 			"integrity": "sha512-oFLl873u4usRM9K63j4ME9u3etNF0PLiJhSQ8rdfuL51Wn3zkD6drf9ZW0dOzjnZI22YYG24z30JcmfCZjMgYg=="
+		},
+		"hoist-non-react-statics": {
+			"version": "3.3.2",
+			"resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+			"integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+			"requires": {
+				"react-is": "^16.7.0"
+			}
 		},
 		"hosted-git-info": {
 			"version": "2.8.9",
@@ -1437,8 +1546,7 @@
 		"js-tokens": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-			"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-			"dev": true
+			"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
 		},
 		"js-yaml": {
 			"version": "3.14.1",
@@ -1541,6 +1649,14 @@
 			"resolved": "https://registry.npmjs.org/lodash.truncate/-/lodash.truncate-4.4.2.tgz",
 			"integrity": "sha1-WjUNoLERO4N+z//VgSy+WNbq4ZM=",
 			"dev": true
+		},
+		"loose-envify": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+			"integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+			"requires": {
+				"js-tokens": "^3.0.0 || ^4.0.0"
+			}
 		},
 		"loud-rejection": {
 			"version": "1.6.0",
@@ -1830,6 +1946,15 @@
 				"wrappy": "1"
 			}
 		},
+		"optimism": {
+			"version": "0.16.1",
+			"resolved": "https://registry.npmjs.org/optimism/-/optimism-0.16.1.tgz",
+			"integrity": "sha512-64i+Uw3otrndfq5kaoGNoY7pvOhSsjFEN4bdEFh80MWVk/dbgJfMv7VFDeCT8LxNAlEVhQmdVEbfE7X2nWNIIg==",
+			"requires": {
+				"@wry/context": "^0.6.0",
+				"@wry/trie": "^0.3.0"
+			}
+		},
 		"optionator": {
 			"version": "0.9.1",
 			"resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
@@ -1979,6 +2104,16 @@
 			"integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
 			"dev": true
 		},
+		"prop-types": {
+			"version": "15.7.2",
+			"resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
+			"integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
+			"requires": {
+				"loose-envify": "^1.4.0",
+				"object-assign": "^4.1.1",
+				"react-is": "^16.8.1"
+			}
+		},
 		"psl": {
 			"version": "1.8.0",
 			"resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
@@ -1999,6 +2134,11 @@
 			"resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
 			"integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
 			"dev": true
+		},
+		"react-is": {
+			"version": "16.13.1",
+			"resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+			"integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
 		},
 		"read-pkg": {
 			"version": "1.1.0",
@@ -2423,6 +2563,11 @@
 			"integrity": "sha512-q5Dq0/QHh4BLJyEVWGe7Cej5NWs040LWjMbicBGZ+3qpFWJ1YObRmUDZKbbovddLC9WW7THTj3kYbTOFmU9fbg==",
 			"dev": true
 		},
+		"svelte-apollo": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/svelte-apollo/-/svelte-apollo-0.4.0.tgz",
+			"integrity": "sha512-VbianysptRx9wy6vQPd2lIRBVKV0XPtrSvqcMctihc5xGl1TVffNp8qsiSlqx2jnOlvOGUSK8xl4GW7C6bzSjw=="
+		},
 		"svelte-hmr": {
 			"version": "0.14.4",
 			"resolved": "https://registry.npmjs.org/svelte-hmr/-/svelte-hmr-0.14.4.tgz",
@@ -2534,8 +2679,7 @@
 		"tslib": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
-			"integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w==",
-			"dev": true
+			"integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w=="
 		},
 		"tsutils": {
 			"version": "3.21.0",
@@ -2864,6 +3008,11 @@
 					"integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
 				}
 			}
+		},
+		"zen-observable": {
+			"version": "0.8.15",
+			"resolved": "https://registry.npmjs.org/zen-observable/-/zen-observable-0.8.15.tgz",
+			"integrity": "sha512-PQ2PC7R9rslx84ndNBZB/Dkv8V8fZEpk83RLgXtYd0fwUgEjseMn1Dgajh2x6S8QbZAFa9p2qVCEuYZNgve0dQ=="
 		}
 	}
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -2563,11 +2563,6 @@
 			"integrity": "sha512-q5Dq0/QHh4BLJyEVWGe7Cej5NWs040LWjMbicBGZ+3qpFWJ1YObRmUDZKbbovddLC9WW7THTj3kYbTOFmU9fbg==",
 			"dev": true
 		},
-		"svelte-apollo": {
-			"version": "0.4.0",
-			"resolved": "https://registry.npmjs.org/svelte-apollo/-/svelte-apollo-0.4.0.tgz",
-			"integrity": "sha512-VbianysptRx9wy6vQPd2lIRBVKV0XPtrSvqcMctihc5xGl1TVffNp8qsiSlqx2jnOlvOGUSK8xl4GW7C6bzSjw=="
-		},
 		"svelte-hmr": {
 			"version": "0.14.4",
 			"resolved": "https://registry.npmjs.org/svelte-hmr/-/svelte-hmr-0.14.4.tgz",

--- a/package.json
+++ b/package.json
@@ -25,12 +25,15 @@
 	},
 	"type": "module",
 	"dependencies": {
+		"@apollo/client": "^3.3.20",
 		"@fontsource/fira-mono": "^4.2.2",
 		"@lukeed/uuid": "^2.0.0",
 		"cookie": "^0.4.1",
+		"graphql": "^15.5.0",
 		"highlight.js": "^10.7.2",
 		"marked": "^2.0.4",
 		"node-sass": "^6.0.0",
-		"sass": "^1.34.0"
+		"sass": "^1.34.0",
+		"svelte-apollo": "^0.4.0"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
 		"highlight.js": "^10.7.2",
 		"marked": "^2.0.4",
 		"node-sass": "^6.0.0",
-		"sass": "^1.34.0",
-		"svelte-apollo": "^0.4.0"
+		"sass": "^1.34.0"
 	}
 }

--- a/src/routes/graphql/post/index.ts
+++ b/src/routes/graphql/post/index.ts
@@ -1,0 +1,19 @@
+import { ApolloClient, InMemoryCache } from '@apollo/client/core';
+import { POST_QUERY } from '../query';
+
+export const get = async (req) => {
+  const id = req.query.get('id');
+  const client = new ApolloClient({
+      uri: 'http://localhost:8080/graphql',
+      cache: new InMemoryCache()
+  });
+  
+  const props = await client.query({
+    query: POST_QUERY, 
+    variables: { id }
+  })
+
+  return {
+    body: props,
+  };
+}

--- a/src/routes/graphql/post/index.ts
+++ b/src/routes/graphql/post/index.ts
@@ -1,4 +1,4 @@
-import { ApolloClient, InMemoryCache } from '@apollo/client/core';
+import { ApolloClient, InMemoryCache } from '@apollo/client/core/core.cjs.js';
 import { POST_QUERY } from '../query';
 
 export const get = async (req) => {

--- a/src/routes/graphql/post/index.ts
+++ b/src/routes/graphql/post/index.ts
@@ -4,7 +4,7 @@ import { POST_QUERY } from '../query';
 export const get = async (req) => {
   const id = req.query.get('id');
   const client = new ApolloClient({
-      uri: 'http://localhost:8080/graphql',
+      uri: 'https://api.takurinton.com/graphql',
       cache: new InMemoryCache()
   });
   

--- a/src/routes/graphql/posts/index.ts
+++ b/src/routes/graphql/posts/index.ts
@@ -7,7 +7,7 @@ export const get = async (req) => {
   const page = req.query.get('page') ?? 1;
 
   const client = new ApolloClient({
-      uri: 'http://localhost:8080/graphql',
+      uri: 'https://api.takurinton.com/graphql',
       cache: new InMemoryCache()
   });
   

--- a/src/routes/graphql/posts/index.ts
+++ b/src/routes/graphql/posts/index.ts
@@ -1,4 +1,4 @@
-import { ApolloClient, InMemoryCache } from '@apollo/client/core';
+import { ApolloClient, InMemoryCache } from '@apollo/client/core/core.cjs.js';
 import { POSTS_QUERY } from '../query';
 
 export const get = async (req) => {

--- a/src/routes/graphql/posts/index.ts
+++ b/src/routes/graphql/posts/index.ts
@@ -1,0 +1,22 @@
+import { ApolloClient, InMemoryCache } from '@apollo/client/core';
+import { POSTS_QUERY } from '../query';
+
+export const get = async (req) => {
+  // なんかここ2重でとってんの無駄に感じてしまうな
+  const category = req.query.get('category') ?? '';
+  const page = req.query.get('page') ?? 1;;
+
+  const client = new ApolloClient({
+      uri: 'http://localhost:8080/graphql',
+      cache: new InMemoryCache()
+  });
+  
+  const props = await client.query({
+    query: POSTS_QUERY, 
+    variables: { page, category }
+  })
+
+  return {
+    body: props,
+  };
+}

--- a/src/routes/graphql/posts/index.ts
+++ b/src/routes/graphql/posts/index.ts
@@ -4,7 +4,7 @@ import { POSTS_QUERY } from '../query';
 export const get = async (req) => {
   // なんかここ2重でとってんの無駄に感じてしまうな
   const category = req.query.get('category') ?? '';
-  const page = req.query.get('page') ?? 1;;
+  const page = req.query.get('page') ?? 1;
 
   const client = new ApolloClient({
       uri: 'http://localhost:8080/graphql',

--- a/src/routes/graphql/query.ts
+++ b/src/routes/graphql/query.ts
@@ -1,0 +1,30 @@
+import { gql } from '@apollo/client/core';
+
+export const POST_QUERY = gql`
+query postQuery($id: Int){
+  getPost (id: $id){
+    id
+    title
+    contents
+    pub_date
+  }
+}
+`
+
+export const POSTS_QUERY = gql`
+query postQuery($page: Int, $category: String){
+  getPosts (page: $page, category: $category){
+    current
+    next
+    previous
+    category
+    results {
+      id
+      title
+      contents
+      category
+      pub_date
+    }
+  }
+}
+`

--- a/src/routes/graphql/query.ts
+++ b/src/routes/graphql/query.ts
@@ -1,4 +1,4 @@
-import { gql } from '@apollo/client/core';
+import { gql } from '@apollo/client/core/core.cjs.js';
 
 export const POST_QUERY = gql`
 query postQuery($id: Int){

--- a/src/routes/index.svelte
+++ b/src/routes/index.svelte
@@ -13,19 +13,18 @@
 		else if (pages === '' && category !== '') params = `?&category=${category}`;
 		else if (pages !== '' && category === '') params = `?page=${pages}`;
 
-		const res = await fetch(`https://api.takurinton.com/blog/v1/${params}`);
+		const res = await fetch(`/graphql/posts${params}`);
 
 		if (res.ok) {
-			const posts = await res.json();
+			const _posts = await res.json();
+			const posts = _posts.data.getPosts;
 			return {
 				props: { posts }
 			};
 		}
 
-		const { message } = await res.json();
-
 		return {
-			error: new Error(message)
+			error: new Error('INTERNAL SERVER ERROR!!!')
 		};
 	};
 </script>
@@ -35,28 +34,23 @@
 	import { flip } from 'svelte/animate';
 
 	type Posts = {
-		next: string | null;
-		previous: string | null;
-		total: number;
-		category: any;
-		current: number;
-		results: Post[];
-		page_size: string;
-		first: string;
-		last: string;
-	};
+        current: number;
+        next: number;
+        previous: number;
+        category: string;
+        results: Post[];
+    }
 
 	type Post = {
-		id: number;
-		title: string;
-		category: string;
-		contents: string;
-		contents_image_url: string;
-		pub_date: string;
-		comment: CommentProps[];
-	};
+        __typename: string;
+        id: number;
+        title: string;
+        contents: string;
+        pub_date: Date;
+    }
 
 	export let posts: Posts;
+	console.log(posts.previous, posts.current, posts.next)
 </script>
 
 <svelte:head>
@@ -75,7 +69,7 @@
 <section>
 	<h1>たくりんとんのブログ</h1>
 
-	{#if posts.category !== null}
+	{#if posts.category !== ''}
 		<h2>{posts.category} の記事一覧</h2>
 	{/if}
 
@@ -97,18 +91,18 @@
 	{/each}
 
 	<div class="pagination">
-		{#if posts.category !== null}
-			{#if posts.next !== null}
+		{#if posts.category !== ''}
+			{#if posts.next !== posts.current}
 				<a class="next-button" href="/?page={posts.next}&category={posts.category}">むかし</a>
 			{/if}
-			{#if posts.previous !== null}
+			{#if posts.previous !== posts.current}
 				<a class="prev-button" href="/?page={posts.previous}&category={posts.category}">さいきん</a>
 			{/if}
 		{:else}
-			{#if posts.next !== null}
+			{#if posts.next !== posts.current}
 				<a class="next-button" href="/?page={posts.next}">むかし</a>
 			{/if}
-			{#if posts.previous !== null}
+			{#if posts.previous !== posts.current}
 				<a class="prev-button" href="/?page={posts.previous}">さいきん</a>
 			{/if}
 		{/if}

--- a/src/routes/index.svelte
+++ b/src/routes/index.svelte
@@ -50,7 +50,6 @@
     }
 
 	export let posts: Posts;
-	console.log(posts.previous, posts.current, posts.next)
 </script>
 
 <svelte:head>

--- a/src/routes/post/[id].svelte
+++ b/src/routes/post/[id].svelte
@@ -1,7 +1,6 @@
 <script context="module" lang="ts">
 	import { enhance } from '$lib/form';
 	import type { Load } from '@sveltejs/kit';
-	import { query } from "svelte-apollo";
 	import marked from 'marked';
 	import { syntaxHighlight, markdownStyle } from './utils.ts';
 

--- a/src/routes/post/[id].svelte
+++ b/src/routes/post/[id].svelte
@@ -1,6 +1,7 @@
 <script context="module" lang="ts">
 	import { enhance } from '$lib/form';
 	import type { Load } from '@sveltejs/kit';
+	import { query } from "svelte-apollo";
 	import marked from 'marked';
 	import { syntaxHighlight, markdownStyle } from './utils.ts';
 
@@ -11,10 +12,11 @@
 	// 引数の fetch は node-fetch 的なやつ、鯖でも走るけど node-fetch 要らず
 	// session や context なども持つことができる、hooks.ts でここら辺も設定できる
 	export const load: Load = async ({ page, fetch }) => {
-		const id: string = page.params.id;
-		const res = await fetch(`https://api.takurinton.com/blog/v1/post/${id}`);
+		const id: number = page.params.id;
+		const res = await fetch(`/graphql/post?id=${id}`);
 		if (res.ok) {
-			const post = await res.json();
+			const _post = await res.json();
+			const post = _post.data.getPost;
 			syntaxHighlight();
 			const r: marked.Renderer = markdownStyle();
 			post.contents = marked(post.contents, { renderer: r });
@@ -26,7 +28,7 @@
 		const { message } = await res.json();
 
 		return {
-			error: new Error(message)
+			error: new Error('internal server error')
 		};
 	};
 </script>
@@ -36,13 +38,11 @@
 	import { flip } from 'svelte/animate';
 
 	type Post = {
+		__typename: string; 
 		id: number;
 		title: string;
-		category: string;
 		contents: string;
-		contents_image_url: string;
 		pub_date: string;
-		comment: CommentProps[];
 	};
 
 	export let post: Post;


### PR DESCRIPTION
## 概要

投稿一覧取得と投稿詳細取得を GraphQL にする。

## 関連

https://github.com/takurinton/blog.takurinton.com/issues/5

## ライブラリ

ざっと目を通した感じ、README 以外にドキュメントがないからやりにくい。(README もうんち)
中身読んで実装するかってなってるけどせっかくやるならしっかりメモって記事にしたい。
[svelte-apollo](https://github.com/timhall/svelte-apollo)
