### PR TITLE
2度目以降のアクセスでレイアウトが崩壊するのを修正

### DIFF
--- a/src/app.scss
+++ b/src/app.scss
@@ -82,6 +82,7 @@ h1 {
 	font-size: 2rem;
 	margin-bottom: 0 0 1em 0;
 	text-align: left;
+	font-weight: 800;
 }
 
 h2 {

--- a/src/app.scss
+++ b/src/app.scss
@@ -65,7 +65,10 @@ p {
 }
 
 p {
-	line-height: 1.5;
+	line-height: 1.8;
+	font-size: 1.2rem;
+	font-weight: 500;
+	
 }
 
 a {

--- a/src/app.scss
+++ b/src/app.scss
@@ -67,8 +67,7 @@ p {
 p {
 	line-height: 1.8;
 	font-size: 1.2rem;
-	font-weight: 500;
-	
+	font-weight: 500;	
 }
 
 a {

--- a/src/app.scss
+++ b/src/app.scss
@@ -122,3 +122,7 @@ button:focus:not(:focus-visible) {
 li {
 	margin: 10px 0;
 }
+
+img {
+	width: 80%;
+}

--- a/src/app.scss
+++ b/src/app.scss
@@ -61,7 +61,6 @@ body::before {
 h1,
 h2,
 p {
-	font-weight: 500;
 	color: $heading;
 }
 
@@ -80,6 +79,7 @@ a:hover {
 
 h1 {
 	font-size: 2rem;
+	margin-top: 30px;
 	margin-bottom: 0 0 1em 0;
 	text-align: left;
 	font-weight: 800;
@@ -87,6 +87,7 @@ h1 {
 
 h2 {
 	font-size: 1.6rem;
+	font-weight: 600;
 }
 
 pre {

--- a/src/lib/Header/index.svelte
+++ b/src/lib/Header/index.svelte
@@ -16,6 +16,7 @@
 	$main-text: #222222;
 	$theme_line: #a8a8a8;
 	$sub-text: #707070;
+	$heading: rgba(0, 0, 0, 0.7);
 
 	$button_color: #ff69b4;
 
@@ -47,7 +48,7 @@
 		padding-left: 20px;
 		float: left;
 		a {
-			color: $main-text;
+			color: $heading;
 			text-decoration: none;
 			font-size: $h4;
 			font-weight: $thick;
@@ -62,7 +63,7 @@
 		line-height: 43px;
 		padding-right: 20px;
 		a {
-			color: $main-text;
+			color: $heading;
 			text-decoration: none;
 			font-size: $h5;
 			font-weight: $thick;

--- a/src/routes/external/index.svelte
+++ b/src/routes/external/index.svelte
@@ -7,7 +7,7 @@
 	export const router = browser;
 	export const prerender = true;
 
-	export const load: Load = async ({ page, fetch }) => {
+	export const load: Load = async ({ fetch }) => {
 		const res = await fetch('/external/rss.json');
 		if (res.ok) {
 			const rss = await res.json();
@@ -24,12 +24,15 @@
 
 <script lang="ts">
 	type rssType = {
-	  title: string;
-	  url: string;
-	  date: string;
+		[key: string]: {
+			title: string;
+			url: string;
+			content: string;
+			date: string;
+    	}[];
 	};
 
-	export let rss: rssType[];
+	export let rss: rssType;
 </script>
 
 <svelte:head>
@@ -51,7 +54,7 @@
 		<div class="box">
 			<div class="content">
 				<a href="{post.url}">
-					<h1><img src="https://simpleicons.org/icons/zenn.svg" /> {post.title}</h1>
+					<h1><img src="https://simpleicons.org/icons/zenn.svg" alt={post.title}/> {post.title}</h1>
 				</a>
 				<p>{post.content}</p>
 			</div>

--- a/src/routes/external/index.svelte
+++ b/src/routes/external/index.svelte
@@ -84,7 +84,7 @@
 	.box {
 		h1 {
 			font-size: $h3;
-			color: $main-text;
+			color: $heading;
 			margin-bottom: 0;
 			&:hover {
 				color: $primary;

--- a/src/routes/external/index.svelte
+++ b/src/routes/external/index.svelte
@@ -23,9 +23,6 @@
 </script>
 
 <script lang="ts">
-	import { scale } from 'svelte/transition';
-	import { flip } from 'svelte/animate';
-
 	type rssType = {
 	  title: string;
 	  url: string;

--- a/src/routes/index.svelte
+++ b/src/routes/index.svelte
@@ -5,7 +5,7 @@
 
 	export const prerender = true;
 
-	export const load: Load = async ({ page, fetch }) => {
+	export const load: Load = async ({ page }) => {
 		const category = page.query.get('category') ?? '';
 		const pages = page.query.get('page') ?? 1;
 
@@ -36,7 +36,7 @@
         title: string;
         contents: string;
 		category: string;
-        pub_date: Date;
+        pub_date: string;
     }
 
 	export let posts: Posts;

--- a/src/routes/index.svelte
+++ b/src/routes/index.svelte
@@ -118,7 +118,6 @@
 
 		h1 {
 			font-size: $h3;
-			color: $main-text;
 			margin-bottom: 0;
 			&:hover {
 				color: $primary;

--- a/src/routes/index.svelte
+++ b/src/routes/index.svelte
@@ -1,7 +1,5 @@
 <script context="module" lang="ts">
-	import { enhance } from '$lib/form';
 	import type { Load } from '@sveltejs/kit';
-	// import { ApolloClient, InMemoryCache } from '@apollo/client/core/core.cjs.js';
 	import { client } from '../lib/graphql/client';
 	import { POSTS_QUERY } from '../lib/graphql/query';
 
@@ -11,20 +9,6 @@
 		const category = page.query.get('category') ?? '';
 		const pages = page.query.get('page') ?? 1;
 
-		// const client = new ApolloClient({
-		// 	uri: 'https://api.takurinton.com/graphql',
-		// 	cache: new InMemoryCache({
-		// 		typePolicies: {
-		// 			getPosts: {
-		// 				keyFields: []
-		// 			}, 
-		// 			getPost: {
-		// 				keyFields: ['id', ]
-		// 			}
-		// 		}
-		// 	})
-		// });
-		
 		const res = await client.query({
 			query: POSTS_QUERY, 
 			variables: { pages, category }
@@ -38,9 +22,6 @@
 </script>
 
 <script lang="ts">
-	import { scale } from 'svelte/transition';
-	import { flip } from 'svelte/animate';
-
 	type Posts = {
         current: number;
         next: number;
@@ -54,6 +35,7 @@
         id: number;
         title: string;
         contents: string;
+		category: string;
         pub_date: Date;
     }
 

--- a/src/routes/post/[id].svelte
+++ b/src/routes/post/[id].svelte
@@ -8,7 +8,7 @@
 
 	export const prerender = true;
 
-	export const load: Load = async ({ page, fetch }) => {
+	export const load: Load = async ({ page }) => {
 		const id: number = Number(page.params.id);
 		const res = await client.query({
 			query: POST_QUERY, 
@@ -19,7 +19,12 @@
 		syntaxHighlight();
 		const r: marked.Renderer = markdownStyle();
 		return {
-			props: { post: { ...post, contents: marked(post.contents, { renderer: r }) } }
+		  props: { 
+			post: { 
+			  ...post, 
+			  contents: marked(post.contents, { renderer: r }) 
+			}
+		  }
 		};
 	};
 </script>

--- a/src/routes/post/[id].svelte
+++ b/src/routes/post/[id].svelte
@@ -67,7 +67,7 @@
 <section>
 	<h1 class="title">{post.title}</h1>
 	<p class="pub-date">{post.pub_date.slice(0, 10)}</p>
-	<div class="main">{@html post.contents}</div>
+	<div class="contents">{@html post.contents}</div>
 </section>
 
 <style lang="scss">
@@ -84,81 +84,11 @@
 		text-align: right;
 	}
 
-	.main {
+	.contents {
 		margin: 3% auto 5%;
 		text-align: left;
-
-		h1 {
-			margin: 4% 0 1% 1%;
-			border-bottom: solid 2px $primary;
-			width: 100%;
-		}
-		h2 {
-			border-bottom: solid 1.6px $primary;
-		}
-		.h2,
-		.h3,
-		.h4,
-		.h5,
-		.h6 {
-			margin: 10px 0 2px 2%;
-		}
-		p {
-			line-height: 2.4;
-			margin-left: 4%;
-			font-weight: 600;
-		}
-
-		a {
-			text-decoration: none;
-			color: $primary;
-		}
-
-		ul {
-			line-height: 2;
-			margin-left: 2%;
-			margin-bottom: 1%;
-			font-weight: 600;
-		}
-
-		img {
-			max-width: 80vw;
-		}
-
-		table {
-			margin-left: 4%;
-			width: auto;
-		}
-
-		table td {
-			word-break: break-all;
-		}
-
-		.content-img {
-			margin: 30px 0 30px 4%;
-		}
-
-		pre {
-			padding: 10px;
-			margin: 10px 0 10px 4%;
-			overflow: auto;
-			background-color: #2c2d3a;
-			border-radius: 5px;
-		}
-		pre > code {
-			font-weight: 500;
-			color: white;
-			font-family: 'SFMono-Regular', 'Consolas', 'Liberation Mono', 'Menlo', monospace,
-				'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
-		}
-
-		code {
-			font-weight: 500;
-			color: black;
-			font-family: 'SFMono-Regular', 'Consolas', 'Liberation Mono', 'Menlo', monospace,
-				'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
-		}
-
+		width: 80%;
+		
 		@media (max-width: 1024px) {
 			width: 90%;
 		}

--- a/src/routes/post/[id].svelte
+++ b/src/routes/post/[id].svelte
@@ -1,27 +1,15 @@
 <script context="module" lang="ts">
-	import { enhance } from '$lib/form';
 	import type { Load } from '@sveltejs/kit';
 	import marked from 'marked';
-	import { syntaxHighlight, markdownStyle } from './utils.ts';
+	import { syntaxHighlight, markdownStyle } from './utils';
 
-	// import { ApolloClient, InMemoryCache } from '@apollo/client/core/core.cjs.js';
 	import { client } from '../../lib/graphql/client';
 	import { POST_QUERY } from '../../lib/graphql/query';
 
 	export const prerender = true;
 
-	// getInitialProps 的なノリのやつ
-	// page はページとかクエリパラメータとかを取得できる
-	// 引数の fetch は node-fetch 的なやつ、鯖でも走るけど node-fetch 要らず
-	// session や context なども持つことができる、hooks.ts でここら辺も設定できる
 	export const load: Load = async ({ page, fetch }) => {
-		const id: number = page.params.id;
-		// const res = await fetch(`/graphql/post?id=${id}`);
-		// const client = new ApolloClient({
-		// 	uri: 'https://api.takurinton.com/graphql',
-		// 	cache: new InMemoryCache()
-		// });
-		
+		const id: number = Number(page.params.id);
 		const res = await client.query({
 			query: POST_QUERY, 
 			variables: { id }
@@ -30,17 +18,13 @@
 		let post = res.data.getPost;
 		syntaxHighlight();
 		const r: marked.Renderer = markdownStyle();
-		post.contents = marked(post.contents, { renderer: r });
 		return {
-			props: { post }
+			props: { post: { ...post, contents: marked(post.contents, { renderer: r }) } }
 		};
 	};
 </script>
 
 <script lang="ts">
-	import { scale } from 'svelte/transition';
-	import { flip } from 'svelte/animate';
-
 	type Post = {
 		__typename: string; 
 		id: number;

--- a/src/routes/post/[id].svelte
+++ b/src/routes/post/[id].svelte
@@ -82,15 +82,19 @@
 	.pub-date {
 		font-size: $p;
 		text-align: right;
+		margin-right: 10%;
 	}
 
 	.contents {
 		margin: 3% auto 5%;
 		text-align: left;
 		width: 80%;
-		
+
 		@media (max-width: 1024px) {
 			width: 90%;
+			.pub-date {
+				margin-right: 5%;
+			}
 		}
 
 		@media screen and (max-width: 500px) {


### PR DESCRIPTION
## 関連リンク

https://github.com/takurinton/blog.takurinton.com/issues/8

## 原因

1回目のレンダリングで markdown を parse して html に変換して、2回目以降のアクセスではその parse 済みの html をさらに parse してレンダリングしようとしてたからおかしくなってた。

## 補足

リファクタも一緒にやる
